### PR TITLE
PR #07: 21/09/2024 - MacOS Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Expected result:
 3. Run the ``cae-cli-macos-installer.sh`` in sudo mode.
 4. Add theses exports on `.zshrc` or `.bash_profile` file: 
 ```bash
-export CAE_CLI_HOME='$HOME/cae' 
-export CAE_META_STRUCTURE_TEMPLATES_PATH='$HOME/cae/file-templates'
+export CAE_CLI_HOME="$HOME/cae"
+export CAE_META_STRUCTURE_TEMPLATES_PATH="$HOME/cae/file-templates"
 ```
 5. Restart terminal with `source ~/.zshrc` or `source ~/.bash_profile`
 6. To test the installation, run ``cae ls``

--- a/README.md
+++ b/README.md
@@ -16,10 +16,30 @@ State Symbol Key:
 <br>
 
 ## 🔧 How to install it
+
+### Windows Plataform
+
 1. Clone the project.
 2. Run the ``cae-cli-installer.exe`` file.
 3. Add ``%CAE_CLI_HOME%`` to your system's or user's Path environment variable.
 4. To test the installation, open a command prompt and run ``cae ls``.
+
+Expected result:
+
+![image](https://github.com/user-attachments/assets/6013f1cc-78e2-42f3-8de2-5669fa174b06)
+
+### MacOS Plataform
+
+1. Clone the project
+2. Authorize file `cae-cli-macos-install.sh` to run with `chmod +x cae-cli-macos-install.sh`
+3. Run the ``cae-cli-macos-installer.sh`` in sudo mode.
+4. Add theses exports on `.zshrc` or `.bash_profile` file: 
+```bash
+export CAE_CLI_HOME='$HOME/cae' 
+export CAE_META_STRUCTURE_TEMPLATES_PATH='$HOME/cae/file-templates'
+```
+5. Restart terminal with `source ~/.zshrc` or `source ~/.bash_profile`
+6. To test the installation, run ``cae ls``
 
 Expected result:
 

--- a/installer/cae-cli-macos-installer.sh
+++ b/installer/cae-cli-macos-installer.sh
@@ -24,6 +24,6 @@ cp ./components/cae-cli.jar "$HOME/cae"
 cp -r ./components/file-templates/* "$HOME/cae/file-templates"
 
 echo "Before use cae-cli, in your .zshrc/.bash_profile file, please add the following lines:"
-echo "export CAE_CLI_HOME='$HOME/cae'"
-echo "export CAE_META_STRUCTURE_TEMPLATES_PATH='$HOME/cae/file-templates'"
+echo "export CAE_CLI_HOME=$HOME/cae"
+echo "export CAE_META_STRUCTURE_TEMPLATES_PATH=$HOME/cae/file-templates"
 echo "Installation completed. Please restart your terminal with 'source ~/.zshrc' or 'source ~/.bash_profile'."

--- a/installer/cae-cli-macos-installer.sh
+++ b/installer/cae-cli-macos-installer.sh
@@ -5,6 +5,7 @@ if [ -d "$HOME/cae" ]; then
 else
   echo "Not found cae directory. Creating it."
   mkdir -p "$HOME/cae"
+  mkdir -p "$HOME/cae/file-templates"
 fi
 
 echo "#!/bin/bash" > "$HOME/cae/cae.sh"
@@ -12,19 +13,19 @@ echo "java -jar \$HOME/cae/cae-cli.jar \"\$@\"" >> "$HOME/cae/cae.sh"
 chmod +x "$HOME/cae/cae.sh"
 
 export CAE_CLI_HOME="$HOME/cae"
-export CAE_META_STRUCTURE_TEMPLATES_PATH="$HOME/cae/file-templates"
 
 if [ -f "$HOME/.zshrc" ]; then
   echo "alias cae='$HOME/cae/cae.sh'" >> "$HOME/.zshrc"
-  echo "export CAE_META_STRUCTURE_TEMPLATES_PATH=\"\$CAE_META_STRUCTURE_TEMPLATES_PATH\"" >> "$HOME/.zshrc"
   source "$HOME/.zshrc"
 elif [ -f "$HOME/.bash_profile" ]; then
   echo "alias cae='$HOME/cae/cae.sh'" >> "$HOME/.bash_profile"
-  echo "export CAE_META_STRUCTURE_TEMPLATES_PATH=\"\$CAE_META_STRUCTURE_TEMPLATES_PATH\"" >> "$HOME/.bash_profile"
   source "$HOME/.bash_profile"
 fi
 
 cp ./components/cae-cli.jar "$HOME/cae"
 cp -r ./components/file-templates "$HOME/cae/file-templates"
 
+echo "Before use cae-clie, in your .zshrc/.bash_profile file, please add the following lines:"
+echo "export CAE_CLI_HOME='$HOME/cae'"
+echo "export CAE_META_STRUCTURE_TEMPLATES_PATH='$HOME/cae/file-templates'"
 echo "Installation completed. Please restart your terminal with 'source ~/.zshrc' or 'source ~/.bash_profile'."

--- a/installer/cae-cli-macos-installer.sh
+++ b/installer/cae-cli-macos-installer.sh
@@ -27,4 +27,4 @@ fi
 cp ./components/cae-cli.jar "$HOME/cae"
 cp -r ./components/file-templates "$HOME/cae/file-templates"
 
-echo "Setup completo! Reinicie o terminal ou execute 'source ~/.zshrc' ou 'source ~/.bash_profile'."
+echo "Installation completed. Please restart your terminal with 'source ~/.zshrc' or 'source ~/.bash_profile'."

--- a/installer/cae-cli-macos-installer.sh
+++ b/installer/cae-cli-macos-installer.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -d "$HOME/cae" ]; then
+  echo "Found the cae directory. Using it."
+else
+  echo "Not found cae directory. Creating it."
+  mkdir -p "$HOME/cae"
+fi
+
+echo "#!/bin/bash" > "$HOME/cae/cae.sh"
+echo "java -jar \$HOME/cae/cae-cli.jar \"\$@\"" >> "$HOME/cae/cae.sh"
+chmod +x "$HOME/cae/cae.sh"
+
+export CAE_CLI_HOME="$HOME/cae"
+export CAE_META_STRUCTURE_TEMPLATES_PATH="$HOME/cae/file-templates"
+
+if [ -f "$HOME/.zshrc" ]; then
+  echo "alias cae='$HOME/cae/cae.sh'" >> "$HOME/.zshrc"
+  echo "export CAE_META_STRUCTURE_TEMPLATES_PATH=\"\$CAE_META_STRUCTURE_TEMPLATES_PATH\"" >> "$HOME/.zshrc"
+  source "$HOME/.zshrc"
+elif [ -f "$HOME/.bash_profile" ]; then
+  echo "alias cae='$HOME/cae/cae.sh'" >> "$HOME/.bash_profile"
+  echo "export CAE_META_STRUCTURE_TEMPLATES_PATH=\"\$CAE_META_STRUCTURE_TEMPLATES_PATH\"" >> "$HOME/.bash_profile"
+  source "$HOME/.bash_profile"
+fi
+
+cp ./components/cae-cli.jar "$HOME/cae"
+cp -r ./components/file-templates "$HOME/cae/file-templates"
+
+echo "Setup completo! Reinicie o terminal ou execute 'source ~/.zshrc' ou 'source ~/.bash_profile'."

--- a/installer/cae-cli-macos-installer.sh
+++ b/installer/cae-cli-macos-installer.sh
@@ -23,7 +23,7 @@ fi
 cp ./components/cae-cli.jar "$HOME/cae"
 cp -r ./components/file-templates/* "$HOME/cae/file-templates"
 
-echo "Before use cae-clie, in your .zshrc/.bash_profile file, please add the following lines:"
+echo "Before use cae-cli, in your .zshrc/.bash_profile file, please add the following lines:"
 echo "export CAE_CLI_HOME='$HOME/cae'"
 echo "export CAE_META_STRUCTURE_TEMPLATES_PATH='$HOME/cae/file-templates'"
 echo "Installation completed. Please restart your terminal with 'source ~/.zshrc' or 'source ~/.bash_profile'."

--- a/installer/cae-cli-macos-installer.sh
+++ b/installer/cae-cli-macos-installer.sh
@@ -23,7 +23,7 @@ elif [ -f "$HOME/.bash_profile" ]; then
 fi
 
 cp ./components/cae-cli.jar "$HOME/cae"
-cp -r ./components/file-templates "$HOME/cae/file-templates"
+cp -r ./components/file-templates/* "$HOME/cae/file-templates"
 
 echo "Before use cae-clie, in your .zshrc/.bash_profile file, please add the following lines:"
 echo "export CAE_CLI_HOME='$HOME/cae'"

--- a/installer/cae-cli-macos-installer.sh
+++ b/installer/cae-cli-macos-installer.sh
@@ -12,8 +12,6 @@ echo "#!/bin/bash" > "$HOME/cae/cae.sh"
 echo "java -jar \$HOME/cae/cae-cli.jar \"\$@\"" >> "$HOME/cae/cae.sh"
 chmod +x "$HOME/cae/cae.sh"
 
-export CAE_CLI_HOME="$HOME/cae"
-
 if [ -f "$HOME/.zshrc" ]; then
   echo "alias cae='$HOME/cae/cae.sh'" >> "$HOME/.zshrc"
   source "$HOME/.zshrc"


### PR DESCRIPTION
Features:
- `.sh` installer for macOS plataform
- Documentation of how install in macOS 

cae-cli working on zsh:
![image](https://github.com/user-attachments/assets/18a62d2c-b7c7-4a75-b46b-7188fddfea8f)
